### PR TITLE
Make code more standardized by including <stdexcept>

### DIFF
--- a/graphw/graphw.hpp
+++ b/graphw/graphw.hpp
@@ -8,6 +8,7 @@
 #include <list>
 #include <queue>
 #include <set>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <vector>


### PR DESCRIPTION
GCC 10.1.0 fails to compile graphw because the `<stdexcept>` header wasn't included. Compiling without this header is non-standard.